### PR TITLE
pref(extension): boss分批渲染，增加请求延迟、减少被风控的可能性

### DIFF
--- a/apps/extension/entrypoints/content/plantforms/boss/index.js
+++ b/apps/extension/entrypoints/content/plantforms/boss/index.js
@@ -20,8 +20,10 @@ import { saveBrowseJob, getJobIds, getAnalysisConfig } from "../../commonDataHan
 import { JobApi } from "../../../../common/api";
 
 const DELAY_FETCH_TIME = 1000; //ms
+const DELAY_FETCH_TIME_NO_LOGIN = 75; //ms
 const DELAY_FETCH_TIME_RANDOM_OFFSET = 50; //ms
 const BATCH_SIZE = 3; // 每批请求的数量
+const BATCH_SIZE_NO_LOGIN = 1000; // 每批请求的数量
 
 export function getBossData(responseText) {
   try {
@@ -90,8 +92,11 @@ function getJobItemDetailUrlFunction(dom) {
 
 // 解析数据，插入时间标签
 export function handleData(list, getListItem, getJobItemDetailUrlFunction, orderStartIndex) {
+  const isBossLogin = isLoggedIn();
   const cardApiUrlList = [];
   const urlList = [];
+  const delayFetchTime = isBossLogin ? DELAY_FETCH_TIME : DELAY_FETCH_TIME_NO_LOGIN;
+  const batchSize = isBossLogin ? BATCH_SIZE : BATCH_SIZE_NO_LOGIN;
   list.forEach((item, index) => {
     const { brandName, securityId } = item;
     const dom = getListItem(index);
@@ -116,12 +121,12 @@ export function handleData(list, getListItem, getJobItemDetailUrlFunction, order
 
   // 分批请求数据
   const fetchBatchData = async (batchIndex) => {
-    const start = batchIndex * BATCH_SIZE;
-    const end = Math.min(start + BATCH_SIZE, cardApiUrlList.length);
+    const start = batchIndex * batchSize;
+    const end = Math.min(start + batchSize, cardApiUrlList.length);
     const batchUrls = cardApiUrlList.slice(start, end);
 
     const promiseList = batchUrls.map(async (url, index) => {
-      await randomDelay(DELAY_FETCH_TIME * index, DELAY_FETCH_TIME_RANDOM_OFFSET); // 避免频繁请求触发风控
+      await randomDelay(delayFetchTime * index, DELAY_FETCH_TIME_RANDOM_OFFSET); // 避免频繁请求触发风控
       const response = await fetch(url);
       const result = await response.json();
       return Object.assign(result.zpData.jobCard, list[start + index]);
@@ -189,7 +194,7 @@ export function handleData(list, getListItem, getJobItemDetailUrlFunction, order
   };
 
   // 逐批请求并处理数据
-  const totalBatches = Math.ceil(cardApiUrlList.length / BATCH_SIZE);
+  const totalBatches = Math.ceil(cardApiUrlList.length / batchSize);
   (async () => {
     for (let i = 0; i < totalBatches; i++) {
       await fetchBatchData(i);
@@ -212,4 +217,21 @@ function createDOM(jobDTO, jobStatusDesc, { analysisConfig }) {
     analysisConfig
   });
   return div;
+}
+
+function isLoggedInByCookie(cookieName) {
+  let cookies = document.cookie;
+  let cookieArray = cookies.split(';');
+  for (let i = 0; i < cookieArray.length; i++) {
+    let cookie = cookieArray[i].trim();
+    if (cookie.startsWith(cookieName + '=')) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isLoggedIn() {
+  const cookieCheck = isLoggedInByCookie('bst'); // 猜测为 boss token
+  return cookieCheck;
 }

--- a/apps/extension/entrypoints/content/plantforms/boss/index.js
+++ b/apps/extension/entrypoints/content/plantforms/boss/index.js
@@ -19,8 +19,9 @@ import { PLATFORM_BOSS } from "../../../../common";
 import { saveBrowseJob, getJobIds, getAnalysisConfig } from "../../commonDataHandler";
 import { JobApi } from "../../../../common/api";
 
-const DELAY_FETCH_TIME = 75; //ms
+const DELAY_FETCH_TIME = 1000; //ms
 const DELAY_FETCH_TIME_RANDOM_OFFSET = 50; //ms
+const BATCH_SIZE = 3; // 每批请求的数量
 
 export function getBossData(responseText) {
   try {
@@ -111,27 +112,35 @@ export function handleData(list, getListItem, getJobItemDetailUrlFunction, order
     );
     dom.appendChild(loadingLastModifyTimeTag);
   });
-  const promiseList = cardApiUrlList.map(async (url, index) => {
-    await randomDelay(DELAY_FETCH_TIME * index, DELAY_FETCH_TIME_RANDOM_OFFSET); // 避免频繁请求触发风控
-    const response = await fetch(url);
-    const result = await response.json();
-    return Object.assign(result.zpData.jobCard, list[index]);
-  });
-  Promise.allSettled(promiseList)
-    .then(async (response) => {
-      const jsonList = response.map(item => item.value);
-      let jobDTOList = [];
-      jsonList.forEach((item, index) => {
-        item.jobUrl = urlList[index];
-      });
-      await saveBrowseJob(jsonList, PLATFORM_BOSS);
-      jobDTOList = await JobApi.getJobBrowseInfoByIds(
-        getJobIds(jsonList, PLATFORM_BOSS)
-      );
-      // const lastModifyTimeList = [];
-      const jobStatusDescList = [];
-      jsonList.forEach((item, index) => {
-        //TODO 字段接口被删除
+  let toalJobDTOList = [];
+
+  // 分批请求数据
+  const fetchBatchData = async (batchIndex) => {
+    const start = batchIndex * BATCH_SIZE;
+    const end = Math.min(start + BATCH_SIZE, cardApiUrlList.length);
+    const batchUrls = cardApiUrlList.slice(start, end);
+
+    const promiseList = batchUrls.map(async (url, index) => {
+      await randomDelay(DELAY_FETCH_TIME * index, DELAY_FETCH_TIME_RANDOM_OFFSET); // 避免频繁请求触发风控
+      const response = await fetch(url);
+      const result = await response.json();
+      return Object.assign(result.zpData.jobCard, list[start + index]);
+    });
+
+    const response = await Promise.allSettled(promiseList);
+    const jsonList = response.map(item => item.value);
+    let jobDTOList = [];
+    jsonList.forEach((item, index) => {
+      item.jobUrl = urlList[start + index];
+    });
+    await saveBrowseJob(jsonList, PLATFORM_BOSS);
+    jobDTOList = await JobApi.getJobBrowseInfoByIds(
+      getJobIds(jsonList, PLATFORM_BOSS)
+    );
+    // const lastModifyTimeList = [];
+    const jobStatusDescList = [];
+    jsonList.forEach((item, index) => {
+       //TODO 字段接口被删除
         // lastModifyTimeList.push(
         //   dayjs(item.value?.zpData?.brandComInfo?.activeTime)
         // );
@@ -139,25 +148,28 @@ export function handleData(list, getListItem, getJobItemDetailUrlFunction, order
         // let jobStatus = convertJobStatusDesc(
         //   item.value?.zpData?.jobInfo?.jobStatusDesc
         // );
-        jobStatusDescList.push(null);
-        // 额外针对BOSS平台，为后面的排序做准备
+      jobStatusDescList.push(null);
+      // 额外针对BOSS平台，为后面的排序做准备
         // jobDTOList[index].jobStatusDesc = null;
-        jobDTOList[
-          index
-        ].jobCompanyApiUrl = `https://www.zhipin.com/gongsi/${item.encryptBrandId}.html`;
-        const hrActiveTimeDesc = item.activeTimeDesc;
-        //额外针对BOSS平台，为后面的排序做准备
-        jobDTOList[index].hrActiveTimeDesc = hrActiveTimeDesc;
-      });
-      const analysisConfig = await getAnalysisConfig();
-      list.forEach((item, index) => {
-        const dom = getListItem(index);
-        const tag = createDOM(jobDTOList[index], jobStatusDescList[index], { analysisConfig });
-        dom.appendChild(tag);
-      });
-      hiddenLoadingDOM();
-      renderSortJobItem(jobDTOList, getListItem, { platform: PLATFORM_BOSS, orderStartIndex });
-      await renderFunctionPanel(jobDTOList, getListItem, {
+      jobDTOList[
+        index
+      ].jobCompanyApiUrl = `https://www.zhipin.com/gongsi/${item.encryptBrandId}.html`;
+      const hrActiveTimeDesc = item.activeTimeDesc;
+      //额外针对BOSS平台，为后面的排序做准备
+      jobDTOList[index].hrActiveTimeDesc = hrActiveTimeDesc;
+    });
+
+    const analysisConfig = await getAnalysisConfig();
+    jsonList.forEach((item, index) => {
+      const dom = getListItem(start + index);
+      const tag = createDOM(jobDTOList[index], jobStatusDescList[index], { analysisConfig });
+      dom.appendChild(tag);
+    });
+
+    await renderFunctionPanel(
+      jobDTOList,
+      (index) => getListItem(start + index),
+      {
         platform: PLATFORM_BOSS,
         getCompanyInfoFunction: async function (url) {
           const response = await fetch(url);
@@ -170,13 +182,25 @@ export function handleData(list, getListItem, getJobItemDetailUrlFunction, order
             return null;
           }
         },
-      });
-      finalRender(jobDTOList, { platform: PLATFORM_BOSS });
-    })
-    .catch((error) => {
-      console.log(error);
-      hiddenLoadingDOM();
-    });
+      }
+    );
+    finalRender(jobDTOList, { platform: PLATFORM_BOSS });
+    toalJobDTOList = toalJobDTOList.concat(jobDTOList);
+  };
+
+  // 逐批请求并处理数据
+  const totalBatches = Math.ceil(cardApiUrlList.length / BATCH_SIZE);
+  (async () => {
+    for (let i = 0; i < totalBatches; i++) {
+      await fetchBatchData(i);
+    }
+    // 重新排序,页面会闪烁
+    renderSortJobItem(toalJobDTOList, getListItem, { platform: PLATFORM_BOSS, orderStartIndex });
+    hiddenLoadingDOM();
+  })().catch((error) => {
+    console.log(error);
+    hiddenLoadingDOM();
+  });
 }
 
 function createDOM(jobDTO, jobStatusDesc, { analysisConfig }) {


### PR DESCRIPTION
使用过程中也遇到了ISSUES中插件触发招聘平台限流的问题（BOSS直聘）https://github.com/lastsunday/job-hunting/issues/70
想着利用 异步渲染和分批渲染、增加请求延迟的方案，应该可以保持用户的使用体验避免高频请求导致的风控问题

代码说明

1. **分批请求数据**：
   - 将数据分成多个批次，每次请求一部分数据，避免一次性请求过多数据。
   - 使用`BATCH_SIZE`常量定义每批请求的数量，可调整。

2. **异步处理数据**：
   - 在每次请求的数据处理完后，立即调用渲染函数进行渲染。
   - 使用`fetchBatchData`函数处理每一批数据。

3. **优化渲染逻辑**：
   - 在每次数据处理完后，立即更新DOM，做到实时渲染。
   - 使用`Promise.allSettled`来处理每一批数据的请求。

4. **增加请求延迟**：
    - `DELAY_FETCH_TIME` 增加至1秒，可调整 (不清楚boss的风控逻辑)

测试包: [job-huntingextension-3.8.1-chrome(boss-batch-render).zip](https://github.com/user-attachments/files/19280284/job-huntingextension-3.8.1-chrome.boss-batch-render.zip)
