### PR TITLE
fix(extension): support new Zhaopin pages

### DIFF
--- a/apps/extension/README.md
+++ b/apps/extension/README.md
@@ -22,7 +22,7 @@
 2. 打开页面
    - boss 直聘： <https://www.zhipin.com/web/geek/jobs>
    - 51Job： <https://we.51job.com/pc/search>
-   - 智联招聘： <https://sou.zhaopin.com/>
+   - 智联招聘： <https://www.zhaopin.com/jobs>、<https://www.zhaopin.com/sou>（可能重定向到 jobs）
    - 拉钩网：<https://www.lagou.com/wn/zhaopin>
    - 猎聘网： <https://www.liepin.com/zhaopin>
    - 就业在线： <https://www.jobonline.cn/position>

--- a/apps/extension/entrypoints/assets/css/app.css
+++ b/apps/extension/entrypoints/assets/css/app.css
@@ -112,6 +112,20 @@
   border-radius: 5px;
 }
 
+/* New Zhilian split-view cards must own their timestamps in normal flow.
+   Absolute positioning anchors all timestamps to the outer page container. */
+.job-list-panel > .job-card > .__zhilian_time_tag {
+  position: static;
+  display: block;
+  width: fit-content;
+  max-width: 100%;
+  box-sizing: border-box;
+  margin-top: 8px;
+  text-align: left;
+  white-space: normal;
+  overflow-wrap: anywhere;
+}
+
 .__jobsdb_time_tag {
   position: absolute;
   right: 0;

--- a/apps/extension/entrypoints/content/commonDataHandler.js
+++ b/apps/extension/entrypoints/content/commonDataHandler.js
@@ -509,9 +509,9 @@ function handleZhilianData(list) {
       welfareLabel,
     } = item;
     const { workAddress, latitude, longitude } =
-      item.jobDetailData.position.workLocation;
-    const { description } = item.jobDetailData.position.desc;
-    const { staffName, hrJob } = item.staffCard;
+      item.jobDetailData?.position?.workLocation || {};
+    const { description } = item.jobDetailData?.position?.desc || {};
+    const { staffName, hrJob } = item.staffCard || {};
     job.jobId = genId(jobId, PLATFORM_ZHILIAN);
     job.jobPlatform = PLATFORM_ZHILIAN;
     job.jobUrl = convertPureJobDetailUrl(positionUrl).replace(
@@ -551,8 +551,10 @@ function handleZhilianData(list) {
     }
     //handle salary month
     const groupsSalaryCount = salaryCount.match(/(?<count>\d*)/)?.groups;
-    job.jobSalaryTotalMonth = groupsSalaryCount.count;
-    job.jobFirstPublishDatetime = convertDateStringToDateObject(publishTime);
+    job.jobSalaryTotalMonth = groupsSalaryCount?.count || null;
+    // Missing publication time is unknown, not today's date.
+    job.jobFirstPublishDatetime = publishTime
+      ? convertDateStringToDateObject(publishTime) : null;
     job.bossName = staffName;
     job.bossCompanyName = companyName;
     job.bossPosition = hrJob;

--- a/apps/extension/entrypoints/content/index.js
+++ b/apps/extension/entrypoints/content/index.js
@@ -2,6 +2,7 @@ import '@webcomponents/custom-elements';
 import { handle as aiqichaHandle } from './company/plantforms/aiqicha/index.js';
 import lagouFirstOpen from './plantforms/lagou/firstOpen.js';
 import zhilianFirstOpen from './plantforms/zhilian/firstOpen.js';
+import { isZhilianListPage } from './plantforms/zhilian/data.js';
 import '@yaireo/dragsort/dist/dragsort.css';
 import '@yaireo/tagify/dist/tagify.css';
 import '../assets/css/app.css';
@@ -37,11 +38,11 @@ export default defineContentScript({
           await initBridge();
           const data = e?.detail?.aiqicha?.initialState?.result?.resultList;
           aiqichaHandle(data, true);
-        } else if (location.host === 'www.zhaopin.com') {
+        } else if (isZhilianListPage(location)) {
           // 智联招聘首次打开
           await initBridge();
           const data = e?.detail?.zhipin?.initialState;
-          zhilianFirstOpen(data || {});
+          await zhilianFirstOpen(data || {});
         }
       } catch (error) {
         console.error('Error handling firstOpen event:', error);

--- a/apps/extension/entrypoints/content/plantforms/zhilian/data.js
+++ b/apps/extension/entrypoints/content/plantforms/zhilian/data.js
@@ -1,0 +1,67 @@
+export const LIST_SELECTOR = '.job-list-panel, .positionlist__list';
+
+export function isZhilianListPage(location) {
+  return location.hostname === 'www.zhaopin.com' &&
+    /^\/(jobs|sou)(\/|$)/.test(location.pathname);
+}
+
+export function isZhilianListResponse(url) {
+  try {
+    const parsed = new URL(url);
+    return /(^|\.)zhaopin\.(com|cn)$/.test(parsed.hostname) &&
+      /^\/c\/i\/(search\/positions|position\/recommend-tag(?:-newest)?)\/?$/.test(parsed.pathname);
+  } catch {
+    return false;
+  }
+}
+
+export function extractList(response) {
+  const data = typeof response === 'string' ? JSON.parse(response) : response;
+  const list = data?.data?.list ?? data?.data?.data?.list ?? data?.positionList;
+  return Array.isArray(list) ? list : [];
+}
+
+export function normalizeJob(item) {
+  // Keep the existing key when present, so stored history remains addressable.
+  const rawId = item.jobId ?? item.number;
+  if ((typeof rawId !== 'string' && typeof rawId !== 'number') ||
+      (typeof rawId === 'number' && (!Number.isSafeInteger(rawId) || rawId <= 0))) return null;
+  const jobId = String(rawId).trim();
+  if (!jobId) return null;
+  return {
+    ...item,
+    jobId,
+    positionUrl: (item.positionUrl || item.positionURL ||
+      `https://www.zhaopin.com/jobdetail/${encodeURIComponent(item.number || jobId)}.htm`)
+      .replace('jobs.zhaopin.com/', 'www.zhaopin.com/jobdetail/'),
+    workingExp: typeof item.workingExp === 'string' ? item.workingExp : '',
+    salaryReal: typeof item.salaryReal === 'string' ? item.salaryReal : '',
+    salaryCount: String(item.salaryCount ?? ''),
+    skillLabel: Array.isArray(item.skillLabel) ? item.skillLabel : [],
+    welfareLabel: Array.isArray(item.welfareLabel) ? item.welfareLabel : [],
+  };
+}
+
+const text = value => String(value ?? '').replace(/\s+/g, '').trim();
+
+export function matchCards(node, list) {
+  if (!node.matches('.job-list-panel')) {
+    return list.map((item, index) => ({ item, dom: node.children[index] }))
+      .filter(({ dom }) => dom && !dom.matches('.pagination'));
+  }
+  const cards = Array.from(node.querySelectorAll(':scope > .job-card'));
+  // The new client-rendered cards have no job URL or ID. Never use array
+  // offsets: pagination appends cards and concurrent requests can reorder them.
+  return cards.flatMap(dom => {
+    const name = text(dom.querySelector('.job-card__title-clamp')?.textContent);
+    const company = text(dom.querySelector('.job-card__company-name')?.textContent);
+    const candidates = list.filter(item => text(item.name) === name &&
+      text(item.companyName) === company);
+    const duplicates = cards.filter(card =>
+      text(card.querySelector('.job-card__title-clamp')?.textContent) === name &&
+      text(card.querySelector('.job-card__company-name')?.textContent) === company);
+    // Ambiguous same-title jobs must not acquire another position's history.
+    return candidates.length === 1 && duplicates.length === 1
+      ? [{ item: candidates[0], dom }] : [];
+  });
+}

--- a/apps/extension/entrypoints/content/plantforms/zhilian/firstOpen.js
+++ b/apps/extension/entrypoints/content/plantforms/zhilian/firstOpen.js
@@ -1,15 +1,6 @@
-import {
-  setupSortJobItem,
-} from "../../commonRender";
-import { parseZhilianData, getListByNode } from "./index";
+import { getZhiLianData } from './index';
 
-
-// 智联招聘首次打开页面时是服务端渲染，没法监听接口，但是 html 中保存了列表数据
-export default async function firstOpen(data) {
-  const dom = document.querySelector(".positionlist__list");
-  setupSortJobItem(dom);
-  const children = dom?.children;
-  const { positionList = [] } = data;
-  if (!children || !positionList || positionList.length === 0) return;
-  parseZhilianData(positionList, getListByNode(dom));
+// SSR and network responses share normalization and deduplication.
+export default function firstOpen(data) {
+  return getZhiLianData(data);
 }

--- a/apps/extension/entrypoints/content/plantforms/zhilian/index.js
+++ b/apps/extension/entrypoints/content/plantforms/zhilian/index.js
@@ -1,94 +1,101 @@
-import { PLATFORM_ZHILIAN } from "../../../../common";
-import { JobApi } from "../../../../common/api";
-import { getJobIds, saveBrowseJob, getAnalysisConfig } from "../../commonDataHandler";
-import {
-  createLoadingDOM,
-  finalRender,
-  hiddenLoadingDOM,
-  renderFunctionPanel,
-  renderSortJobItem,
-  renderTimeTag,
-  setupSortJobItem
-} from "../../commonRender";
-// const DELAY_FETCH_TIME = 75; //ms
-// const DELAY_FETCH_TIME_RANDOM_OFFSET = 50; //ms
+import { PLATFORM_ZHILIAN } from '../../../../common';
+import { JobApi } from '../../../../common/api';
+import { getJobIds, saveBrowseJob, getAnalysisConfig } from '../../commonDataHandler';
+import { finalRender, renderFunctionPanel, renderSortJobItem, renderTimeTag, setupSortJobItem } from '../../commonRender';
+import { LIST_SELECTOR, extractList, normalizeJob, matchCards } from './data';
 
-export function getZhiLianData(responseText) {
+let pending = Promise.resolve();
+
+export function getZhiLianData(response) {
   try {
-    const data = JSON.parse(responseText);
-    mutationContainer().then((node) => {
-      setupSortJobItem(node);
-      parseZhilianData(data?.data?.list || [], getListByNode(node));
-    });
-  } catch (err) {
-    console.error("解析 JSON 失败", err);
+    const rawList = extractList(response);
+    const list = rawList.map(normalizeJob).filter(Boolean);
+    console.info('[job-hunting] zhilian fix.3', { received: rawList.length, valid: list.length });
+    if (!list.length) return Promise.resolve();
+    pending = pending.then(async () => {
+      const pairs = await waitForCards(list);
+      if (!pairs.length) console.warn('[job-hunting] 智联：未找到可唯一匹配的职位卡片');
+      if (pairs.length) await parseZhilianData(
+        pairs.map(pair => pair.item), index => pairs[index]?.dom,
+      );
+    }).catch(error => console.error('[job-hunting] 智联适配失败', error));
+    return pending;
+  } catch (error) {
+    console.error('[job-hunting] 智联响应解析失败', error);
+    return Promise.resolve();
   }
 }
 
-// 获取职位列表节点
 export function getListByNode(node) {
-  const children = node?.children;
-  return function getListItem(index) {
-    return children?.[index];
-  };
+  const children = Array.from(node?.children || []);
+  return index => children[index];
 }
 
-// 监听 positionList-hook 节点，判断职位列表是否被挂载
-function mutationContainer() {
-  return new Promise((resolve, reject) => {
-    const dom = document.querySelector(".positionlist__list");
-    const observer = new MutationObserver(function (childList) {
-      const isAdd = (childList || []).some((item) => {
-        return item?.addedNodes?.length > 0;
-      });
-      return isAdd ? resolve(dom) : reject("未找到职位列表");
-    });
-
-    observer.observe(dom, {
-      childList: true,
-      subtree: false,
-    });
+// Check existing cards as well as containers mounted after the response.
+function waitForCards(list) {
+  return new Promise(resolve => {
+    let timer;
+    const finish = pairs => {
+      clearTimeout(timer);
+      observer.disconnect();
+      resolve(pairs);
+    };
+    const check = () => {
+      const node = document.querySelector(LIST_SELECTOR);
+      const pairs = node ? matchCards(node, list) : [];
+      if (pairs.length) finish(pairs);
+    };
+    const observer = new MutationObserver(check);
+    observer.observe(document.documentElement, { childList: true, subtree: true });
+    timer = setTimeout(() => finish([]), 5000);
+    check();
   });
 }
 
-// 解析数据，插入时间标签
 export async function parseZhilianData(list, getListItem) {
-  list.forEach((item, index) => {
-    const dom = getListItem(index);
-    const { companyName } = item;
-    const loadingLastModifyTimeTag = createLoadingDOM(
-      companyName,
-      "__zhilian_time_tag"
-    );
-    dom.appendChild(loadingLastModifyTimeTag);
-  });
-  await saveBrowseJob(list, PLATFORM_ZHILIAN);
-  const jobDTOList = await JobApi.getJobBrowseInfoByIds(
-    getJobIds(list, PLATFORM_ZHILIAN)
-  );
-  const analysisConfig = await getAnalysisConfig();
-  list.forEach((item, index) => {
-    const dom = getListItem(index);
-    const tag = createDOM(jobDTOList[index], { analysisConfig });
-    dom.appendChild(tag);
-  });
-  hiddenLoadingDOM();
-  renderSortJobItem(
-    jobDTOList,
-    getListItem,
-    { platform: PLATFORM_ZHILIAN }
-  );
-  await renderFunctionPanel(
-    jobDTOList,
-    getListItem,
-    { platform: PLATFORM_ZHILIAN }
-  );
-  finalRender(jobDTOList, { platform: PLATFORM_ZHILIAN });
+  const pairs = list.map((item, index) => ({ item, dom: getListItem(index) }))
+    .filter(({ item, dom }) => dom?.isConnected &&
+      dom.dataset.jobHuntingZhilianId !== item.jobId);
+  if (!pairs.length) return;
+  // firstOpen and proxyAjax are separate bundles; reserve through the DOM.
+  pairs.forEach(({ item, dom }) => { dom.dataset.jobHuntingZhilianId = item.jobId; });
+  try {
+    const jobs = pairs.map(pair => pair.item);
+    await saveBrowseJob(jobs, PLATFORM_ZHILIAN);
+    const dtos = await JobApi.getJobBrowseInfoByIds(getJobIds(jobs, PLATFORM_ZHILIAN));
+    const dtoById = new Map(dtos.map(dto => [dto.jobId, dto]));
+    const analysisConfig = await getAnalysisConfig();
+    const current = pairs.filter(({ item, dom }) => {
+      const stillMatches = dom.isConnected &&
+        (!dom.parentElement.matches('.job-list-panel') ||
+          matchCards(dom.parentElement, jobs).some(pair => pair.dom === dom && pair.item.jobId === item.jobId));
+      const valid = stillMatches && dom.dataset.jobHuntingZhilianId === item.jobId &&
+        dtoById.has(`ZHILIAN_${item.jobId}`);
+      if (!valid && dom.dataset.jobHuntingZhilianId === item.jobId) delete dom.dataset.jobHuntingZhilianId;
+      return valid;
+    });
+    if (!current.length) return;
+    const getDom = index => current[index].dom;
+    const currentDtos = current.map(({ item }) => dtoById.get(`ZHILIAN_${item.jobId}`));
+    current.forEach(({ dom }, index) => {
+      dom.querySelectorAll('.__zhilian_time_tag').forEach(tag => tag.remove());
+      dom.appendChild(createDOM(currentDtos[index], { analysisConfig }));
+    });
+    setupSortJobItem(current[0].dom.parentElement);
+    renderSortJobItem(currentDtos, getDom, { platform: PLATFORM_ZHILIAN });
+    await renderFunctionPanel(currentDtos, getDom, { platform: PLATFORM_ZHILIAN });
+    finalRender(currentDtos, { platform: PLATFORM_ZHILIAN });
+  } catch (error) {
+    pairs.forEach(({ item, dom }) => {
+      if (dom.dataset.jobHuntingZhilianId === item.jobId) delete dom.dataset.jobHuntingZhilianId;
+    });
+    throw error;
+  }
 }
 
 export function createDOM(jobDTO, { analysisConfig } = {}) {
-  const div = document.createElement("div");
-  div.classList.add("__zhilian_time_tag");
+  const div = document.createElement('div');
+  div.classList.add('__zhilian_time_tag');
   renderTimeTag(div, jobDTO, { analysisConfig });
   return div;
 }

--- a/apps/extension/entrypoints/proxyAjax.content/index.js
+++ b/apps/extension/entrypoints/proxyAjax.content/index.js
@@ -5,6 +5,7 @@ import { getJob51Data } from '../content/plantforms/job51/index.js';
 import { getJobsdbData } from '../content/plantforms/jobsdb/index.js';
 import { getLiepinData } from '../content/plantforms/liepin/index.js';
 import { getZhiLianData } from '../content/plantforms/zhilian/index.js';
+import { isZhilianListPage, isZhilianListResponse } from '../content/plantforms/zhilian/data.js';
 import { getLaGouData } from '../content/plantforms/lagou/index.js';
 import { handle as aiqichaHandle } from '../content/company/plantforms/aiqicha/index.js';
 import { getJobOnlineData } from '../content/plantforms/jobonline/index.js';
@@ -30,7 +31,9 @@ export default defineContentScript({
   main(ctx) {
     console.log(`[Inject] proxy ajax content js`);
     (async () => {
-      await initBridge();
+      const bridgeReady = initBridge();
+      // Capture Zhilian's initial client-side request while the DB starts.
+      if (window.location.hostname !== 'www.zhaopin.com') await bridgeReady;
       // Executed when content script is loaded, can be async
       // 这里的 window 和页面的 window 不是同一个
       window.$ = window.jQuery = $;
@@ -39,6 +42,7 @@ export default defineContentScript({
       window.addEventListener('ajaxGetData', async function (e) {
         const data = e?.detail;
         if (!data) return;
+        await bridgeReady;
         const responseURL = data?.responseURL;
         if (responseURL) {
           // boss直聘推荐页/搜索页接口
@@ -66,8 +70,8 @@ export default defineContentScript({
           }
 
           // 智联招聘接口
-          if (responseURL.indexOf('/search/positions') !== -1) {
-            getZhiLianData(data?.response, true);
+          if (isZhilianListPage(window.location) && isZhilianListResponse(responseURL)) {
+            await getZhiLianData(data?.response);
           }
 
           // 前程无忧接口

--- a/apps/extension/public/proxyAjax.js
+++ b/apps/extension/public/proxyAjax.js
@@ -65,3 +65,27 @@ window.addEventListener("ajaxReadyStateChange", async function (e) {
 });
 
 console.log("[Inject] proxy ajax");
+
+// New Zhilian pages may use fetch as well as XMLHttpRequest. Observe only
+// position-list responses and clone them so the site's consumer is unaffected.
+if (window.location.hostname === 'www.zhaopin.com') {
+  const originalFetch = window.fetch;
+  window.fetch = function (...args) {
+    return originalFetch.apply(this, args).then(response => {
+      try {
+        const url = new URL(response.url);
+        if (response.ok && /(^|\.)zhaopin\.(com|cn)$/.test(url.hostname) &&
+            /^\/c\/i\/(search\/positions|position\/recommend-tag(?:-newest)?)\/?$/.test(url.pathname)) {
+          response.clone().text().then(text => {
+            window.dispatchEvent(new CustomEvent('ajaxGetData', {
+              detail: { response: text, responseURL: response.url, status: response.status },
+            }));
+          }).catch(error => console.error('[job-hunting] 智联 fetch 响应读取失败', error));
+        }
+      } catch (error) {
+        console.error('[job-hunting] 智联 fetch 监听失败', error);
+      }
+      return response;
+    });
+  };
+}

--- a/apps/extension/tests/zhilian.test.js
+++ b/apps/extension/tests/zhilian.test.js
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { extractList, normalizeJob, matchCards, isZhilianListPage, isZhilianListResponse } from '../entrypoints/content/plantforms/zhilian/data';
+
+const api = vi.hoisted(() => ({ save: vi.fn(), get: vi.fn(), panel: vi.fn() }));
+vi.mock('../common/api', () => ({ JobApi: { getJobBrowseInfoByIds: api.get } }));
+vi.mock('../entrypoints/content/commonDataHandler', () => ({
+  saveBrowseJob: api.save,
+  getJobIds: list => list.map(item => `ZHILIAN_${item.jobId}`),
+  getAnalysisConfig: async () => ({}),
+}));
+vi.mock('../entrypoints/content/commonRender', () => ({
+  finalRender: vi.fn(), renderFunctionPanel: api.panel,
+  renderSortJobItem: vi.fn(), setupSortJobItem: vi.fn(),
+  renderTimeTag: (dom, dto) => { dom.textContent = dto.jobId; },
+}));
+import { getZhiLianData } from '../entrypoints/content/plantforms/zhilian/index';
+
+const job = (number = 'CC123J456') => ({ number, name: '运维工程师', companyName: '测试公司' });
+const card = (name = '运维工程师') => `<div class="job-card"><div class="job-card__title-clamp">${name}</div><a class="job-card__company-name">测试公司</a></div>`;
+beforeEach(() => {
+  document.body.innerHTML = `<div class="job-list-panel">${card()}</div>`;
+  vi.clearAllMocks();
+  api.get.mockImplementation(async ids => ids.map(jobId => ({ jobId })).reverse());
+});
+
+describe('Zhilian page and payload compatibility', () => {
+  it('matches new routes with boundaries and exact list endpoints', () => {
+    for (const path of ['/jobs', '/jobs?kw=test', '/sou', '/sou/'])
+      expect(isZhilianListPage(new URL(`https://www.zhaopin.com${path}`))).toBe(true);
+    expect(isZhilianListPage(new URL('https://www.zhaopin.com/jobs-other'))).toBe(false);
+    for (const path of ['/c/i/search/positions', '/c/i/position/recommend-tag', '/c/i/position/recommend-tag-newest'])
+      expect(isZhilianListResponse(`https://api.zhaopin.com${path}?page=2`)).toBe(true);
+    expect(isZhilianListResponse('https://example.com/c/i/search/positions')).toBe(false);
+  });
+  it('reads search, recommendation, JSON XHR and SSR lists', () => {
+    const list = [job()];
+    expect(extractList(JSON.stringify({ data: { list } }))).toEqual(list);
+    expect(extractList({ data: { data: { list } } })).toEqual(list);
+    expect(extractList({ positionList: list })).toEqual(list);
+    expect(extractList({ data: { list: {} } })).toEqual([]);
+  });
+  it('preserves existing IDs and tolerates absent optional fields', () => {
+    expect(normalizeJob({ ...job(), jobId: 'old-id' }).jobId).toBe('old-id');
+    expect(normalizeJob(job())).toMatchObject({ jobId: 'CC123J456', skillLabel: [], salaryCount: '' });
+    expect(normalizeJob({ name: 'no ID' })).toBeNull();
+    expect(normalizeJob(job()).publishTime).toBeUndefined();
+  });
+  it('matches appended cards by identity and skips ambiguous names', () => {
+    const node = document.querySelector('.job-list-panel');
+    node.innerHTML = card('旧岗位') + card();
+    expect(matchCards(node, [job()])[0].dom).toBe(node.children[1]);
+    expect(matchCards(node, [job(), job('other-id')])).toEqual([]);
+  });
+});
+
+describe('Zhilian injection lifecycle', () => {
+  it('renders the numeric jobId shape observed in the live SSR page', async () => {
+    const liveShape = {
+      jobId: 40967514415, number: 'CC634415720J40967514415',
+      name: '系统运维工程师', companyName: '杭州杭途科技有限公司',
+      positionUrl: 'http://www.zhaopin.com/jobdetail/CC634415720J40967514415.htm',
+      publishTime: '2026-09-03 19:21:19', firstPublishTime: '',
+      salaryReal: '8001-10000', salaryCount: '',
+    };
+    document.body.innerHTML = '<div class="job-list-panel"><div class="job-card"><div class="job-card__title-clamp">系统运维工程师</div><a class="job-card__company-name">杭州杭途科技有限公司</a></div></div>';
+    await getZhiLianData({ positionList: [liveShape] });
+    expect(api.save.mock.calls[0][0][0]).toMatchObject({ jobId: '40967514415', publishTime: liveShape.publishTime });
+    expect(document.querySelector('.__zhilian_time_tag').textContent).toBe('ZHILIAN_40967514415');
+    expect(normalizeJob({ ...liveShape, positionUrl: undefined }).positionUrl).toContain(liveShape.number);
+    expect(normalizeJob({ jobId: NaN })).toBeNull();
+    expect(normalizeJob({ jobId: Number.MAX_SAFE_INTEGER + 1 })).toBeNull();
+  });
+  it('renders existing cards and deduplicates SSR plus XHR', async () => {
+    await getZhiLianData({ positionList: [job()] });
+    await getZhiLianData({ data: { list: [job()] } });
+    expect(api.save).toHaveBeenCalledTimes(1);
+    expect(document.querySelectorAll('.__zhilian_time_tag')).toHaveLength(1);
+    expect(document.querySelector('.__zhilian_time_tag').textContent).toBe('ZHILIAN_CC123J456');
+  });
+  it('waits for a container mounted after the response', async () => {
+    document.body.innerHTML = '';
+    const pending = getZhiLianData({ data: { list: [job()] } });
+    await Promise.resolve();
+    document.body.innerHTML = `<div class="job-list-panel">${card()}</div>`;
+    await pending;
+    expect(document.querySelector('.__zhilian_time_tag')).not.toBeNull();
+  });
+  it('uses DTO IDs rather than database result order', async () => {
+    document.querySelector('.job-list-panel').innerHTML += card('开发工程师');
+    await getZhiLianData({ data: { list: [job(), { ...job('second'), name: '开发工程师' }] } });
+    expect([...document.querySelectorAll('.__zhilian_time_tag')].map(e => e.textContent))
+      .toEqual(['ZHILIAN_CC123J456', 'ZHILIAN_second']);
+  });
+  it('allows retry after a database failure', async () => {
+    api.save.mockRejectedValueOnce(new Error('database unavailable'));
+    await getZhiLianData({ positionList: [job()] });
+    await getZhiLianData({ positionList: [job()] });
+    expect(document.querySelectorAll('.__zhilian_time_tag')).toHaveLength(1);
+  });
+});

--- a/apps/extension/tests/zhilianFetch.test.js
+++ b/apps/extension/tests/zhilianFetch.test.js
@@ -1,0 +1,30 @@
+import { readFileSync } from 'node:fs';
+import { runInNewContext } from 'node:vm';
+import { expect, it, vi } from 'vitest';
+
+it('observes only Zhilian list fetches without consuming or replacing the response', async () => {
+  const source = readFileSync('public/proxyAjax.js', 'utf8');
+  const listeners = new Map();
+  const events = [];
+  const text = vi.fn(async () => '{"data":{"list":[]}}');
+  const clone = vi.fn(() => ({ text }));
+  const response = { ok: true, status: 200, url: 'https://api.zhaopin.com/c/i/search/positions', clone };
+  const fetch = vi.fn(async () => response);
+  const window = {
+    location: { hostname: 'www.zhaopin.com' }, fetch, Event: function () {},
+    addEventListener: (name, callback) => listeners.set(name, callback),
+    dispatchEvent: event => events.push(event),
+  };
+  const document = { createEvent: () => ({ initCustomEvent(name, bubbles, cancelable, detail) { this.type = name; this.detail = detail; } }) };
+  runInNewContext(source, { window, document, XMLHttpRequest: function () {}, URL, crypto: {}, console });
+  expect(await window.fetch('/test')).toBe(response);
+  await Promise.resolve();
+  expect(clone).toHaveBeenCalledTimes(1);
+  expect(events[0]).toMatchObject({ type: 'ajaxGetData', detail: { responseURL: response.url } });
+  response.url = 'https://example.com/c/i/search/positions';
+  await window.fetch('/other');
+  expect(clone).toHaveBeenCalledTimes(1);
+  const error = new Error('network failed');
+  fetch.mockRejectedValueOnce(error);
+  await expect(window.fetch('/failed')).rejects.toBe(error);
+});


### PR DESCRIPTION
## 问题

智联招聘新版职位页面已迁移到新的页面结构，原有适配无法在新版页面正常识别和处理职位数据。

## 修改内容

- 适配智联招聘新版职位列表页面
- 更新新版页面的数据解析逻辑
- 调整职位列表注入和渲染逻辑
- 更新相关 Ajax / Fetch 处理
- 保留职位历史记录和首次发现时间功能
- 增加智联相关测试

## 测试环境

- Windows 11
- Microsoft Edge
- 智联招聘新版职位页面
- 已登录状态

## 测试结果

已在 Microsoft Edge 中对智联招聘新版职位列表页进行实际测试。

- 新版 `www.zhaopin.com/jobs` 职位列表可以正常识别
- job-hunting 增强信息可以正常注入并显示
- 职位首次发现/发布时间相关信息可以正常展示
- 公司信息、职位标签及职位评论等功能可以正常显示

### 测试截图

<img width="1536" height="1024" alt="QQ截图" src="https://github.com/user-attachments/assets/21778f1f-9cf8-489b-a7c8-dbcb7121f3c9" />


